### PR TITLE
mark replies as replies to parent

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -45,7 +45,7 @@ private
     @reply_info = ReplyInfoVerifier.generate(user, post)
 
     if post.previous_message_id
-      headers["References"] = headers["In-Reply-To"] = post.previous_message_id
+      headers["References"] = "thread-#{post.thread_id}/post-1@community.recurse.com"
     end
 
     mail(


### PR DESCRIPTION
Community presents threads linearly, but the emails present them as if every message were a response to the previous, causing them to march off the right side of the screen in a tree view.